### PR TITLE
fix link to the T5X sprint paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@ Monty Evans, Undergraduate at UNC<br />
         <h2><a href="#publications" style="text-decoration: none;" id="publications">Recent publications</a></h2>  <i>(<a href="http://colinraffel.com/cv.html#publications">full list</a>)</i>
 
 
-        <p><a href="https://arxiv.org/abs/2203.17189">What Language Model Architecture and Pretraining Objective Work Best for Zero-Shot Generalization?</a><br />
+        <p><a href="https://arxiv.org/abs/2204.05832">What Language Model Architecture and Pretraining Objective Work Best for Zero-Shot Generalization?</a><br />
         Thomas Wang*, Adam Roberts*, Daniel Hesslow, Teven Le Scao, Hyung Won Chung, Iz Beltagy, Julien Launay, and <b>Colin Raffel</b><br />
         <i>39th International Conference on Machine Learning (ICML)</i>, 2022 (to appear).<br />
 


### PR DESCRIPTION
Currently, “What Language Model Architecture and Pretraining Objective Work Best for Zero-Shot Generalization?” is incorrectly linking to the “Scaling Up Models and Data with 𝚝𝟻𝚡 and 𝚜𝚎𝚚𝚒𝚘” paper.